### PR TITLE
Fix coverage

### DIFF
--- a/commands/test.go
+++ b/commands/test.go
@@ -130,7 +130,7 @@ func (c TestCommand) Execute() int {
 
 			coverageReport, err := tf.NewCoverageReportFromState(state)
 			if err != nil {
-				log.Fatalf("[ERROR] error produce coverage report: %+v", err)
+				log.Printf("[ERROR] error produce coverage report: %+v", err)
 			}
 			log.Printf("[INFO] the coverage report has been produced.")
 			storePassReport(passReport, coverageReport, reportDir, allPassedReportFileName)
@@ -158,7 +158,7 @@ func (c TestCommand) Execute() int {
 	passReport := tf.NewPassReport(plan)
 	coverageReport, err := tf.NewCoverageReport(plan)
 	if err != nil {
-		log.Fatalf("[ERROR] error produce coverage report: %+v", err)
+		log.Printf("[ERROR] error produce coverage report: %+v", err)
 	}
 	storePassReport(passReport, coverageReport, reportDir, partialPassedReportFileName)
 

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -28,6 +28,7 @@ type Model struct {
 	TotalCount              int                `json:"TotalCount,omitempty"`
 	Type                    *string            `json:"Type,omitempty"`
 	Variants                *map[string]*Model `json:"Variants,omitempty"`
+	VariantType             *string            `json:"VariantType,omitempty"`
 }
 
 func (m *Model) MarkCovered(root interface{}) {

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -22,6 +22,7 @@ type Model struct {
 	IsReadOnly              bool               `json:"IsReadOnly,omitempty"`
 	IsRequired              bool               `json:"IsRequired,omitempty"`
 	Item                    *Model             `json:"Item,omitempty"`
+	ModelName               string             `json:"ModelName,omitempty"`
 	Properties              *map[string]*Model `json:"Properties,omitempty"`
 	SourceFile              string             `json:"SourceFile,omitempty"`
 	TotalCount              int                `json:"TotalCount,omitempty"`

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -74,10 +74,10 @@ func (m *Model) MarkCovered(root interface{}) {
 			for k, v := range value {
 				if k == *m.Discriminator {
 					if m.ModelName == v.(string) {
-						break Loop
+						break
 					}
 					if m.VariantType != nil && *m.VariantType == v.(string) {
-						break Loop
+						break
 					}
 					if variant, ok := (*m.Variants)[v.(string)]; ok {
 						isMatchProperty = false

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -108,7 +108,7 @@ func (m *Model) MarkCovered(root interface{}) {
 	case nil:
 
 	default:
-		log.Fatalf("[ERROR] unexpect type %T for json unmarshaled value", value)
+		log.Printf("[ERROR] unexpect type %T for json unmarshaled value", value)
 	}
 }
 

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -21,14 +21,48 @@ type testCase struct {
 	resourceType string
 }
 
-func TestCoverageResourceGroup(t *testing.T) {
+func TestCoverage_DataMigrationTasks(t *testing.T) {
+	tc := testCase{
+		name:         "DataMigrationTasks",
+		resourceType: "Microsoft.DataMigration/services/projects/tasks@2021-06-30",
+		apiVersion:   "2021-06-30",
+		apiPath:      "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/DmsSdkRg/providers/Microsoft.DataMigration/services/DmsSdkService/projects/DmsSdkProject/tasks/DmsSdkTask",
+		rawRequest: []string{`{
+    "taskType": "ConnectToTarget.SqlDb",
+    "input": {
+        "targetConnectionInfo": {
+            "type": "SqlConnectionInfo",
+            "dataSource": "ssma-test-server.database.windows.net",
+            "authentication": "SqlAuthentication",
+            "encryptConnection": true,
+            "trustServerCertificate": true,
+            "userName": "testuser",
+            "password": "testpassword"
+        }
+    }
+}`,
+		},
+	}
+
+	model, err := testCoverage(t, tc)
+	if err != nil {
+		t.Fatalf("process coverage: %+v", err)
+	}
+
+	if model.CoveredCount != 1 {
+		t.Fatalf("expected CoveredCount 1, got %d", model.CoveredCount)
+	}
+}
+
+func TestCoverage_ResourceGroup(t *testing.T) {
 	tc := testCase{
 		name:         "ResourceGroup",
 		resourceType: "Microsoft.Resources/resourceGroups@2022-09-01",
 		apiVersion:   "2022-09-01",
 		apiPath:      "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/rgName",
-		rawRequest: []string{
-			`{"location": "westeurope"}`,
+		rawRequest: []string{`{
+    "location": "westeurope"
+}`,
 		},
 	}
 
@@ -58,7 +92,40 @@ func TestCoverageResourceGroup(t *testing.T) {
 	}
 }
 
-func TestCoverageKeyVault(t *testing.T) {
+func TestCoverage_DeviceSecurityGroup(t *testing.T) {
+	tc := testCase{
+		name:         "DeviceSecurityGroup",
+		resourceType: "Microsoft.Security/deviceSecurityGroups@2019-08-01",
+		apiVersion:   "2019-08-01",
+		apiPath:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SampleRG/providers/Microsoft.Devices/iotHubs/sampleiothub/providers/Microsoft.Security/deviceSecurityGroups/samplesecuritygroup",
+		rawRequest: []string{`{
+    "properties": {
+        "timeWindowRules": [
+            {
+                "ruleType": "ActiveConnectionsNotInAllowedRange",
+                "isEnabled": true,
+                "minThreshold": 0,
+                "maxThreshold": 30,
+                "timeWindowSize": "PT05M"
+            }
+        ]
+    }
+}
+`,
+		},
+	}
+
+	model, err := testCoverage(t, tc)
+	if err != nil {
+		t.Fatalf("process coverage: %+v", err)
+	}
+
+	if model.CoveredCount != 5 {
+		t.Fatalf("expected CoveredCount 5, got %d", model.CoveredCount)
+	}
+}
+
+func TestCoverage_KeyVault(t *testing.T) {
 	tc := testCase{
 		name:         "KeyVault",
 		resourceType: "Microsoft.KeyVault/vaults@2023-02-01",
@@ -144,7 +211,7 @@ func TestCoverageKeyVault(t *testing.T) {
 
 }
 
-func TestCoverageStorageAccount(t *testing.T) {
+func TestCoverage_StorageAccount(t *testing.T) {
 	tc := testCase{
 		name:         "StorageAccount",
 		resourceType: "Microsoft.Storage/storageAccounts@2022-09-01",
@@ -211,7 +278,7 @@ func TestCoverageStorageAccount(t *testing.T) {
 	}
 }
 
-func TestCoverageVM(t *testing.T) {
+func TestCoverage_VM(t *testing.T) {
 	tc := testCase{
 		name:         "VM",
 		resourceType: "Microsoft.Compute/virtualMachines@2023-03-01",
@@ -281,7 +348,7 @@ func TestCoverageVM(t *testing.T) {
 
 }
 
-func TestCoverageVNet(t *testing.T) {
+func TestCoverage_VNet(t *testing.T) {
 	tc := testCase{
 		name:         "VNet",
 		resourceType: "Microsoft.Network/virtualNetworks@2023-02-01",
@@ -318,7 +385,7 @@ func TestCoverageVNet(t *testing.T) {
 	}
 }
 
-func TestCoverageDataCollectionRule(t *testing.T) {
+func TestCoverage_DataCollectionRule(t *testing.T) {
 	tc := testCase{
 		name:         "DataCollectionRule",
 		resourceType: "Microsoft.Insights/dataCollectionRules@2022-06-01",
@@ -644,7 +711,7 @@ func TestCoverageDataCollectionRule(t *testing.T) {
 
 }
 
-func TestCoverageWebSite(t *testing.T) {
+func TestCoverage_WebSite(t *testing.T) {
 	tc := testCase{
 		name:         "WebSites",
 		resourceType: "Microsoft.Web/sites@2022-09-01",
@@ -671,7 +738,7 @@ func TestCoverageWebSite(t *testing.T) {
 
 }
 
-func TestCoverageAKS(t *testing.T) {
+func TestCoverage_AKS(t *testing.T) {
 	tc := testCase{
 		name:         "AKS",
 		resourceType: "Microsoft.ContainerService/ManagedClusters@2023-05-02-preview",
@@ -761,7 +828,7 @@ func TestCoverageAKS(t *testing.T) {
 
 }
 
-func TestCoverageCosmosDB(t *testing.T) {
+func TestCoverage_CosmosDB(t *testing.T) {
 	tc := testCase{
 		name:         "CosmosDB",
 		resourceType: "Microsoft.DocumentDB/databaseAccounts@2023-04-15",
@@ -854,8 +921,8 @@ func TestCoverageCosmosDB(t *testing.T) {
 		t.Fatalf("process coverage: %v", err)
 	}
 
-	if model.CoveredCount != 34 {
-		t.Fatalf("expected CoveredCount 34, got %d", model.CoveredCount)
+	if model.CoveredCount != 33 {
+		t.Fatalf("expected CoveredCount 33, got %d", model.CoveredCount)
 	}
 
 	if model.Properties == nil {
@@ -988,7 +1055,102 @@ func TestCoverageCosmosDB(t *testing.T) {
 
 }
 
-func TestCoverageDataFactoryLinkedServices(t *testing.T) {
+func TestCoverage_DataFactoryPipelines(t *testing.T) {
+	tc := testCase{
+		name:         "DataFactoryPipelines",
+		apiVersion:   "2018-06-01",
+		resourceType: "Microsoft.DataFactory/factories/pipelines@2018-06-01",
+		apiPath:      "/subscriptions/12345678-1234-1234-1234-12345678abc/resourceGroups/exampleResourceGroup/providers/Microsoft.DataFactory/factories/exampleFactoryName/pipelines/examplePipeline",
+		rawRequest: []string{`{
+    "properties": {
+        "activities": [
+            {
+                "type": "ForEach",
+                "typeProperties": {
+                    "isSequential": true,
+                    "items": {
+                        "value": "@pipeline().parameters.OutputBlobNameList",
+                        "type": "Expression"
+                    },
+                    "activities": [
+                        {
+                            "type": "Copy",
+                            "typeProperties": {
+                                "source": {
+                                    "type": "BlobSource"
+                                },
+                                "sink": {
+                                    "type": "BlobSink"
+                                },
+                                "dataIntegrationUnits": 32
+                            },
+                            "inputs": [
+                                {
+                                    "referenceName": "exampleDataset",
+                                    "parameters": {
+                                        "MyFolderPath": "examplecontainer",
+                                        "MyFileName": "examplecontainer.csv"
+                                    },
+                                    "type": "DatasetReference"
+                                }
+                            ],
+                            "outputs": [
+                                {
+                                    "referenceName": "exampleDataset",
+                                    "parameters": {
+                                        "MyFolderPath": "examplecontainer",
+                                        "MyFileName": {
+                                            "value": "@item()",
+                                            "type": "Expression"
+                                        }
+                                    },
+                                    "type": "DatasetReference"
+                                }
+                            ],
+                            "name": "ExampleCopyActivity"
+                        }
+                    ]
+                },
+                "name": "ExampleForeachActivity"
+            }
+        ],
+        "parameters": {
+            "OutputBlobNameList": {
+                "type": "Array"
+            },
+            "JobId": {
+                "type": "String"
+            }
+        },
+        "variables": {
+            "TestVariableArray": {
+                "type": "Array"
+            }
+        },
+        "runDimensions": {
+            "JobId": {
+                "value": "@pipeline().parameters.JobId",
+                "type": "Expression"
+            }
+        },
+        "policy": {
+            "elapsedTimeMetric": {
+                "duration": "0.00:10:00"
+            }
+        }
+    }
+}
+`,
+		},
+	}
+
+	_, err := testCoverage(t, tc)
+	if err != nil {
+		t.Fatalf("process coverage: %+v", err)
+	}
+}
+
+func TestCoverage_DataFactoryLinkedServices(t *testing.T) {
 	tc := testCase{
 		name:         "DataFactoryLinkedServices",
 		resourceType: "Microsoft.DataFactory/factories/linkedServices@2018-06-01",
@@ -1013,8 +1175,8 @@ func TestCoverageDataFactoryLinkedServices(t *testing.T) {
 		t.Fatalf("process coverage: %+v", err)
 	}
 
-	if model.CoveredCount != 3 {
-		t.Fatalf("expected TotalCount 3, got %d", model.CoveredCount)
+	if model.CoveredCount != 2 {
+		t.Fatalf("expected TotalCount 2, got %d", model.CoveredCount)
 	}
 
 	if model.Properties == nil {
@@ -1029,8 +1191,8 @@ func TestCoverageDataFactoryLinkedServices(t *testing.T) {
 		t.Fatalf("expected properties type property, got none")
 	}
 
-	if !(*(*model.Properties)["properties"].Properties)["type"].IsAnyCovered {
-		t.Fatalf("expected properties type IsAnyCovered true, got false")
+	if (*(*model.Properties)["properties"].Properties)["type"].IsAnyCovered {
+		t.Fatalf("expected properties type IsAnyCovered false, got true")
 	}
 
 	if (*model.Properties)["properties"].Discriminator == nil {
@@ -1088,6 +1250,8 @@ func testCoverage(t *testing.T, tc testCase) (*coverage.Model, error) {
 		tc.apiVersion,
 	)
 
+	t.Logf("swaggerModel: %+v", swaggerModel)
+
 	if err != nil {
 		return nil, fmt.Errorf("get model info from index: %+v", err)
 	}
@@ -1107,14 +1271,13 @@ func testCoverage(t *testing.T, tc testCase) (*coverage.Model, error) {
 		model.MarkCovered(request)
 	}
 
+	model.CountCoverage()
+
 	out, err := json.MarshalIndent(model, "", "\t")
 	if err != nil {
 		t.Error(err)
 	}
-
-	t.Logf("expanded model %s", string(out))
-
-	model.CountCoverage()
+	t.Logf("coverage model %s", string(out))
 
 	coverageReport := coverage.CoverageReport{
 		Coverages: map[coverage.ArmResource]*coverage.Model{

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -59,6 +59,105 @@ func TestCoverage_ResourceGroup(t *testing.T) {
 	}
 }
 
+func TestCoverage_MachineLearningServicesWorkspacesJobs(t *testing.T) {
+	tc := testCase{
+		name:         "MachineLearningServicesWorkspacesJobs",
+		resourceType: "Microsoft.MachineLearningServices/workspaces/jobs",
+		apiVersion:   "2023-06-01-preview",
+		apiPath:      "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/rg1/providers/Microsoft.MachineLearningServices/workspaces/works1/jobs/job1",
+		rawRequest: []string{`{
+    "properties": {
+        "description": "string",
+        "tags": {
+            "string": "string"
+        },
+        "properties": {
+            "string": "string"
+        },
+        "displayName": "string",
+        "experimentName": "string",
+        "services": {
+            "string": {
+                "jobServiceType": "string",
+                "port": 1,
+                "endpoint": "string",
+                "properties": {
+                    "string": "string"
+                }
+            }
+        },
+        "computeId": "string",
+        "jobType": "Pipeline",
+        "settings": {},
+        "inputs": {
+            "string": {
+                "description": "string",
+                "jobInputType": "literal",
+                "value": "string"
+            }
+        },
+        "outputs": {
+            "string": {
+                "description": "string",
+                "jobOutputType": "uri_file",
+                "mode": "Upload",
+                "uri": "string"
+            }
+        }
+    }
+}`,
+		},
+	}
+
+	model, err := testCoverage(t, tc)
+	if err != nil {
+		t.Fatalf("process coverage: %+v", err)
+	}
+
+	expected := 11
+	if model.CoveredCount != expected {
+		t.Fatalf("expected CoveredCount %d, got %d", expected, model.CoveredCount)
+	}
+}
+
+func TestCoverage_MachineLearningServicesWorkspacesDataVersions(t *testing.T) {
+	tc := testCase{
+		name:         "MachineLearningServicesWorkspacesDataVersions",
+		resourceType: "Microsoft.MachineLearningServices/workspaces/data/versions",
+		apiVersion:   "2023-06-01-preview",
+		apiPath:      "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/rg1/providers/Microsoft.MachineLearningServices/workspaces/works1/data/data1/versions/version1",
+		rawRequest: []string{`{
+    "properties": {
+        "description": "string",
+        "tags": {
+            "string": "string"
+        },
+        "properties": {
+            "string": "string"
+        },
+        "isArchived": false,
+        "isAnonymous": false,
+        "dataUri": "string",
+        "dataType": "mltable",
+        "referencedUris": [
+            "string"
+        ]
+    }
+}`,
+		},
+	}
+
+	model, err := testCoverage(t, tc)
+	if err != nil {
+		t.Fatalf("process coverage: %+v", err)
+	}
+
+	expected := 8
+	if model.CoveredCount != expected {
+		t.Fatalf("expected CoveredCount %d, got %d", expected, model.CoveredCount)
+	}
+}
+
 func TestCoverage_DeviceSecurityGroup(t *testing.T) {
 	tc := testCase{
 		name:         "DeviceSecurityGroup",
@@ -87,13 +186,14 @@ func TestCoverage_DeviceSecurityGroup(t *testing.T) {
 		t.Fatalf("process coverage: %+v", err)
 	}
 
-	if model.CoveredCount != 5 {
-		t.Fatalf("expected CoveredCount 5, got %d", model.CoveredCount)
+	expected := 5
+	if model.CoveredCount != expected {
+		t.Fatalf("expected CoveredCount %d, got %d", expected, model.CoveredCount)
 	}
 }
 
 func TestCoverage_DataMigrationServiceTasks(t *testing.T) {
-	// TODO: support cross file discriminator reference, e.g., https://github.com/Azure/azure-rest-api-specs/blob/0ab5469dc0d75594f5747493dcfe8774e22d728f/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2021-06-30/definitions/ServiceTasks.json#L39
+	// Do we need to support cross file discriminator reference? Now seems only DataMigration has this. e.g., https://github.com/Azure/azure-rest-api-specs/blob/0ab5469dc0d75594f5747493dcfe8774e22d728f/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2021-06-30/definitions/ServiceTasks.json#L39
 	tc := testCase{
 		name:         "DataMigrationServiceTasks",
 		resourceType: "Microsoft.DataMigration/services/serviceTasks@2021-06-30",
@@ -146,8 +246,9 @@ func TestCoverage_DataMigrationTasks(t *testing.T) {
 		t.Fatalf("process coverage: %+v", err)
 	}
 
-	if model.CoveredCount != 8 {
-		t.Fatalf("expected CoveredCount 8, got %d", model.CoveredCount)
+	expected := 8
+	if model.CoveredCount != expected {
+		t.Fatalf("expected CoveredCount %d, got %d", expected, model.CoveredCount)
 	}
 }
 
@@ -231,8 +332,9 @@ func TestCoverage_KeyVault(t *testing.T) {
 		t.Fatalf("process coverage: %+v", err)
 	}
 
-	if model.CoveredCount != 13 {
-		t.Fatalf("expected CoveredCount 13, got %d", model.CoveredCount)
+	expected := 13
+	if model.CoveredCount != expected {
+		t.Fatalf("expected CoveredCount %d, got %d", expected, model.CoveredCount)
 	}
 
 }
@@ -299,8 +401,9 @@ func TestCoverage_StorageAccount(t *testing.T) {
 		t.Fatalf("process coverage: %+v", err)
 	}
 
-	if model.CoveredCount != 24 {
-		t.Fatalf("expected CoveredCount 24, got %d", model.CoveredCount)
+	expected := 24
+	if model.CoveredCount != expected {
+		t.Fatalf("expected CoveredCount %d, got %d", expected, model.CoveredCount)
 	}
 }
 
@@ -368,8 +471,9 @@ func TestCoverage_VM(t *testing.T) {
 		t.Fatalf("process coverage: %+v", err)
 	}
 
-	if model.CoveredCount != 20 {
-		t.Fatalf("expected CoveredCount 20, got %d", model.CoveredCount)
+	expected := 20
+	if model.CoveredCount != expected {
+		t.Fatalf("expected CoveredCount %d, got %d", expected, model.CoveredCount)
 	}
 
 }
@@ -406,8 +510,9 @@ func TestCoverage_VNet(t *testing.T) {
 		t.Fatalf("process coverage: %+v", err)
 	}
 
-	if model.CoveredCount != 4 {
-		t.Fatalf("expected CoveredCount 4, got %d", model.CoveredCount)
+	expected := 4
+	if model.CoveredCount != expected {
+		t.Fatalf("expected CoveredCount %d, got %d", expected, model.CoveredCount)
 	}
 }
 
@@ -731,8 +836,9 @@ func TestCoverage_DataCollectionRule(t *testing.T) {
 		t.Fatalf("process coverage: %+v", err)
 	}
 
-	if model.CoveredCount != 65 {
-		t.Fatalf("expected CoveredCount 65, got %d", model.CoveredCount)
+	expected := 65
+	if model.CoveredCount != expected {
+		t.Fatalf("expected CoveredCount %d, got %d", expected, model.CoveredCount)
 	}
 
 }
@@ -758,8 +864,9 @@ func TestCoverage_WebSite(t *testing.T) {
 		t.Fatalf("process coverage: %+v", err)
 	}
 
-	if model.CoveredCount != 3 {
-		t.Fatalf("expected CoveredCount 3, got %d", model.CoveredCount)
+	expected := 3
+	if model.CoveredCount != expected {
+		t.Fatalf("expected CoveredCount %d, got %d", expected, model.CoveredCount)
 	}
 
 }
@@ -848,8 +955,9 @@ func TestCoverage_AKS(t *testing.T) {
 		t.Fatalf("process coverage: %+v", err)
 	}
 
-	if model.CoveredCount != 33 {
-		t.Fatalf("expected TotalCount 33, got %d", model.CoveredCount)
+	expected := 33
+	if model.CoveredCount != expected {
+		t.Fatalf("expected TotalCount %d, got %d", expected, model.CoveredCount)
 	}
 
 }
@@ -947,8 +1055,9 @@ func TestCoverage_CosmosDB(t *testing.T) {
 		t.Fatalf("process coverage: %v", err)
 	}
 
-	if model.CoveredCount != 33 {
-		t.Fatalf("expected CoveredCount 33, got %d", model.CoveredCount)
+	expected := 33
+	if model.CoveredCount != expected {
+		t.Fatalf("expected CoveredCount %d, got %d", expected, model.CoveredCount)
 	}
 
 	if model.Properties == nil {
@@ -1170,9 +1279,14 @@ func TestCoverage_DataFactoryPipelines(t *testing.T) {
 		},
 	}
 
-	_, err := testCoverage(t, tc)
+	model, err := testCoverage(t, tc)
 	if err != nil {
 		t.Fatalf("process coverage: %+v", err)
+	}
+
+	expected := 11
+	if model.CoveredCount != expected {
+		t.Fatalf("expected TotalCount %d, got %d", expected, model.CoveredCount)
 	}
 }
 
@@ -1201,8 +1315,9 @@ func TestCoverage_DataFactoryLinkedServices(t *testing.T) {
 		t.Fatalf("process coverage: %+v", err)
 	}
 
-	if model.CoveredCount != 2 {
-		t.Fatalf("expected TotalCount 2, got %d", model.CoveredCount)
+	expected := 2
+	if model.CoveredCount != expected {
+		t.Fatalf("expected TotalCount %d, got %d", expected, model.CoveredCount)
 	}
 
 	if model.Properties == nil {
@@ -1233,40 +1348,44 @@ func TestCoverage_DataFactoryLinkedServices(t *testing.T) {
 		t.Fatalf("expected properties variants, got none")
 	}
 
-	if v, ok := (*(*model.Properties)["properties"].Variants)["AzureStorage"]; !ok || v == nil {
-		t.Fatalf("expected properties variant AzureStorage, got none")
+	if v, ok := (*(*model.Properties)["properties"].Variants)["AzureStorageLinkedService"]; !ok || v == nil {
+		t.Fatalf("expected properties variant AzureStorageLinkedService, got none")
 	}
 
-	if (*(*model.Properties)["properties"].Variants)["AzureStorage"].Properties == nil {
-		t.Fatalf("expected properties variant AzureStorage properties, got none")
+	if v := (*(*model.Properties)["properties"].Variants)["AzureStorageLinkedService"].VariantType; v == nil || *v != "AzureStorage" {
+		t.Fatalf("expected properties variant AzureStorageLinkedService variant type AzureStorage")
 	}
 
-	if v, ok := (*(*(*model.Properties)["properties"].Variants)["AzureStorage"].Properties)["type"]; !ok || v == nil {
-		t.Fatalf("expected properties variant AzureStorage type property, got none")
+	if (*(*model.Properties)["properties"].Variants)["AzureStorageLinkedService"].Properties == nil {
+		t.Fatalf("expected properties variant AzureStorageLinkedService properties, got none")
 	}
 
-	if !(*(*(*model.Properties)["properties"].Variants)["AzureStorage"].Properties)["type"].IsAnyCovered {
-		t.Fatalf("expected properties variant AzureStorage type IsAnyCovered true, got false")
+	if v, ok := (*(*(*model.Properties)["properties"].Variants)["AzureStorageLinkedService"].Properties)["type"]; !ok || v == nil {
+		t.Fatalf("expected properties variant AzureStorageLinkedService type property, got none")
 	}
 
-	if v, ok := (*(*(*model.Properties)["properties"].Variants)["AzureStorage"].Properties)["typeProperties"]; !ok || v == nil {
-		t.Fatalf("expected properties variant AzureStorage typeProperties property, got none")
+	if !(*(*(*model.Properties)["properties"].Variants)["AzureStorageLinkedService"].Properties)["type"].IsAnyCovered {
+		t.Fatalf("expected properties variant AzureStorageLinkedService type IsAnyCovered true, got false")
 	}
 
-	if !(*(*(*model.Properties)["properties"].Variants)["AzureStorage"].Properties)["typeProperties"].IsAnyCovered {
-		t.Fatalf("expected properties variant AzureStorage typeProperties IsAnyCovered true, got false")
+	if v, ok := (*(*(*model.Properties)["properties"].Variants)["AzureStorageLinkedService"].Properties)["typeProperties"]; !ok || v == nil {
+		t.Fatalf("expected properties variant AzureStorageLinkedService typeProperties property, got none")
 	}
 
-	if (*(*(*model.Properties)["properties"].Variants)["AzureStorage"].Properties)["typeProperties"].Properties == nil {
-		t.Fatalf("expected properties variant AzureStorage typeProperties properties, got none")
+	if !(*(*(*model.Properties)["properties"].Variants)["AzureStorageLinkedService"].Properties)["typeProperties"].IsAnyCovered {
+		t.Fatalf("expected properties variant AzureStorageLinkedService typeProperties IsAnyCovered true, got false")
 	}
 
-	if v, ok := (*(*(*(*model.Properties)["properties"].Variants)["AzureStorage"].Properties)["typeProperties"].Properties)["connectionString"]; !ok || v == nil {
-		t.Fatalf("expected properties variant AzureStorage typeProperties connectionString property, got none")
+	if (*(*(*model.Properties)["properties"].Variants)["AzureStorageLinkedService"].Properties)["typeProperties"].Properties == nil {
+		t.Fatalf("expected properties variant AzureStorageLinkedService typeProperties properties, got none")
 	}
 
-	if !(*(*(*(*model.Properties)["properties"].Variants)["AzureStorage"].Properties)["typeProperties"].Properties)["connectionString"].IsAnyCovered {
-		t.Fatalf("expected properties variant AzureStorage typeProperties connectionString IsAnyCovered true, got false")
+	if v, ok := (*(*(*(*model.Properties)["properties"].Variants)["AzureStorageLinkedService"].Properties)["typeProperties"].Properties)["connectionString"]; !ok || v == nil {
+		t.Fatalf("expected properties variant AzureStorageLinkedService typeProperties connectionString property, got none")
+	}
+
+	if !(*(*(*(*model.Properties)["properties"].Variants)["AzureStorageLinkedService"].Properties)["typeProperties"].Properties)["connectionString"].IsAnyCovered {
+		t.Fatalf("expected properties variant AzureStorageLinkedService typeProperties connectionString IsAnyCovered true, got false")
 	}
 }
 

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -21,39 +21,6 @@ type testCase struct {
 	resourceType string
 }
 
-func TestCoverage_DataMigrationTasks(t *testing.T) {
-	tc := testCase{
-		name:         "DataMigrationTasks",
-		resourceType: "Microsoft.DataMigration/services/projects/tasks@2021-06-30",
-		apiVersion:   "2021-06-30",
-		apiPath:      "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/DmsSdkRg/providers/Microsoft.DataMigration/services/DmsSdkService/projects/DmsSdkProject/tasks/DmsSdkTask",
-		rawRequest: []string{`{
-    "taskType": "ConnectToTarget.SqlDb",
-    "input": {
-        "targetConnectionInfo": {
-            "type": "SqlConnectionInfo",
-            "dataSource": "ssma-test-server.database.windows.net",
-            "authentication": "SqlAuthentication",
-            "encryptConnection": true,
-            "trustServerCertificate": true,
-            "userName": "testuser",
-            "password": "testpassword"
-        }
-    }
-}`,
-		},
-	}
-
-	model, err := testCoverage(t, tc)
-	if err != nil {
-		t.Fatalf("process coverage: %+v", err)
-	}
-
-	if model.CoveredCount != 1 {
-		t.Fatalf("expected CoveredCount 1, got %d", model.CoveredCount)
-	}
-}
-
 func TestCoverage_ResourceGroup(t *testing.T) {
 	tc := testCase{
 		name:         "ResourceGroup",
@@ -122,6 +89,41 @@ func TestCoverage_DeviceSecurityGroup(t *testing.T) {
 
 	if model.CoveredCount != 5 {
 		t.Fatalf("expected CoveredCount 5, got %d", model.CoveredCount)
+	}
+}
+
+func TestCoverage_DataMigrationTasks(t *testing.T) {
+	tc := testCase{
+		name:         "DataMigrationTasks",
+		resourceType: "Microsoft.DataMigration/services/projects/tasks@2021-06-30",
+		apiVersion:   "2021-06-30",
+		apiPath:      "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/DmsSdkRg/providers/Microsoft.DataMigration/services/DmsSdkService/projects/DmsSdkProject/tasks/DmsSdkTask",
+		rawRequest: []string{`{
+    "properties": {
+        "taskType": "ConnectToTarget.SqlDb",
+        "input": {
+            "targetConnectionInfo": {
+                "type": "SqlConnectionInfo",
+                "dataSource": "ssma-test-server.database.windows.net",
+                "authentication": "SqlAuthentication",
+                "encryptConnection": true,
+                "trustServerCertificate": true,
+                "userName": "testuser",
+                "password": "testpassword"
+            }
+        }
+    }
+}`,
+		},
+	}
+
+	model, err := testCoverage(t, tc)
+	if err != nil {
+		t.Fatalf("process coverage: %+v", err)
+	}
+
+	if model.CoveredCount != 8 {
+		t.Fatalf("expected CoveredCount 8, got %d", model.CoveredCount)
 	}
 }
 
@@ -1261,6 +1263,12 @@ func testCoverage(t *testing.T, tc testCase) (*coverage.Model, error) {
 		return nil, fmt.Errorf("expand model: %+v", err)
 	}
 
+	out, err := json.MarshalIndent(model, "", "\t")
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("expand model %s", string(out))
+
 	for _, rq := range tc.rawRequest {
 		request := map[string]interface{}{}
 		err = json.Unmarshal([]byte(rq), &request)
@@ -1273,7 +1281,7 @@ func testCoverage(t *testing.T, tc testCase) (*coverage.Model, error) {
 
 	model.CountCoverage()
 
-	out, err := json.MarshalIndent(model, "", "\t")
+	out, err = json.MarshalIndent(model, "", "\t")
 	if err != nil {
 		t.Error(err)
 	}

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -92,6 +92,30 @@ func TestCoverage_DeviceSecurityGroup(t *testing.T) {
 	}
 }
 
+func TestCoverage_DataMigrationServiceTasks(t *testing.T) {
+	// TODO: support cross file discriminator reference, e.g., https://github.com/Azure/azure-rest-api-specs/blob/0ab5469dc0d75594f5747493dcfe8774e22d728f/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2021-06-30/definitions/ServiceTasks.json#L39
+	tc := testCase{
+		name:         "DataMigrationServiceTasks",
+		resourceType: "Microsoft.DataMigration/services/serviceTasks@2021-06-30",
+		apiVersion:   "2021-06-30",
+		apiPath:      "/subscriptions/fc04246f-04c5-437e-ac5e-206a19e7193f/resourceGroups/DmsSdkRg/providers/Microsoft.DataMigration/services/DmsSdkService/serviceTasks/DmsSdkTask",
+		rawRequest: []string{`{
+    "properties": {
+        "taskType": "Service.Check.OCI",
+        "input": {
+            "serverVersion": "NA"
+        }
+    }
+}`,
+		},
+	}
+
+	_, err := testCoverage(t, tc)
+	if err != nil {
+		t.Fatalf("process coverage: %+v", err)
+	}
+}
+
 func TestCoverage_DataMigrationTasks(t *testing.T) {
 	tc := testCase{
 		name:         "DataMigrationTasks",

--- a/coverage/expand.go
+++ b/coverage/expand.go
@@ -146,8 +146,6 @@ func expandSchema(input openapiSpec.Schema, swaggerPath, modelName, identifier s
 	properties := make(map[string]*Model)
 
 	// expand ref
-	a := input.Ref.String()
-	a = a
 	if input.Ref.String() != "" {
 		resolved, err := openapiSpec.ResolveRefWithBase(root, &input.Ref, &openapiSpec.ExpandOptions{RelativeBase: swaggerPath})
 		if err != nil {
@@ -157,7 +155,7 @@ func expandSchema(input openapiSpec.Schema, swaggerPath, modelName, identifier s
 		refSwaggerPath := swaggerPath
 		modelName, relativePath := SchemaNamePathFromRef(input.Ref)
 		if relativePath != "" {
-			refSwaggerPath = filepath.Join(filepath.Dir(swaggerPath), relativePath)
+			refSwaggerPath = filepath.Join(filepath.Dir(refSwaggerPath), relativePath)
 			refSwaggerPath = strings.Replace(refSwaggerPath, "https:/", "https://", 1)
 
 			doc, err := loadSwagger(refSwaggerPath)
@@ -282,6 +280,7 @@ func expandSchema(input openapiSpec.Schema, swaggerPath, modelName, identifier s
 						if variantNameRaw, ok := schema.Extensions[msExtensionDiscriminator]; ok && variantNameRaw != nil {
 							variantName = variantNameRaw.(string)
 						}
+
 						resolved := expandSchema(schema, swaggerPath, variantModelName, identifier+"{"+variantName+"}", root, resolvedDiscriminator, resolvedModel)
 						variants[variantName] = resolved
 						if varVarSet, ok := allOfTable[variantModelName]; ok {

--- a/coverage/expand_test.go
+++ b/coverage/expand_test.go
@@ -3,8 +3,10 @@ package coverage_test
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -29,14 +31,87 @@ func TestExpand_MediaTransform(t *testing.T) {
 	t.Logf("expanded model %s", string(out))
 }
 
+func TestExpandLocal_basic(t *testing.T) {
+	swaggerPath := "./testdata/"
+	pathRef := jsonreference.MustCreateRef("test1.json#/paths/~1path1/put")
+	swaggerModel, err := coverage.GetModelInfoFromIndexRef(openapispec.Ref{Ref: pathRef}, swaggerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if swaggerModel.ModelName != "pet" {
+		t.Fatalf("expected modelName pet, got %s", swaggerModel.ModelName)
+	}
+
+	model, err := coverage.Expand(swaggerModel.ModelName, swaggerModel.SwaggerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := json.MarshalIndent(model, "", "\t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("expanded model %s", string(out))
+
+	if model.Properties == nil {
+		t.Fatalf("expected properties not nil")
+	}
+
+	if _, ok := (*model.Properties)["odata.type"]; !ok {
+		t.Fatalf("expected properties odata.type string")
+	}
+
+	if model.Variants == nil {
+		t.Fatalf("expected variants not nil")
+	}
+
+	if model.Discriminator == nil || *model.Discriminator != "odata.type" {
+		t.Fatalf("expected discriminator odata.type")
+	}
+
+	if model.VariantType == nil || *model.VariantType != "animal.pet" {
+		t.Fatalf("expected variantType animal.pet")
+	}
+
+	if _, ok := (*model.Variants)["animal.pet.dog"]; !ok {
+		t.Fatalf("expected variants dog not nil")
+	}
+
+	if (*model.Variants)["animal.pet.dog"].Properties == nil {
+		t.Fatalf("expected variants dog properties not nil")
+	}
+
+	if (*model.Variants)["animal.pet.dog"].VariantType == nil || *(*model.Variants)["animal.pet.dog"].VariantType != "animal.pet.dog" {
+		t.Fatalf("expected variants dog variantType animal.pet.dog")
+	}
+
+	if _, ok := (*(*model.Variants)["animal.pet.dog"].Properties)["odata.type"]; !ok {
+		t.Fatalf("expected variants dog properties odata.type string")
+	}
+
+	if _, ok := (*(*model.Variants)["animal.pet.dog"].Properties)["name"]; !ok {
+		t.Fatalf("expected variants dog properties name")
+	}
+
+	if _, ok := (*(*model.Variants)["animal.pet.dog"].Properties)["is_barking"]; !ok {
+		t.Fatalf("expected variants dog properties name")
+	}
+
+}
+
 // try to expand all PUT and POST models
 func TestExpandAll(t *testing.T) {
+	// AZURE_REST_REPO_DIR="/home/test/go/src/github.com/azure/azure-rest-api-specs/specification" TEST_RESULT_FILE="/home/test/res.json"
 	azureRepoDir := os.Getenv("AZURE_REST_REPO_DIR")
 	if azureRepoDir == "" {
 		t.Skip("AZURE_REST_REPO_DIR is not set")
 	}
-	if !strings.HasSuffix(azureRepoDir, "/specification") {
-		t.Fatalf("AZURE_REST_REPO_DIR must specify the specification folder, e.g., AZURE_REST_REPO_DIR=\"/home/test/go/src/github.com/azure/azure-rest-api-specs/specification\"")
+	if strings.HasSuffix(azureRepoDir, "specification") {
+		azureRepoDir += "/"
+	}
+	if !strings.HasSuffix(azureRepoDir, "specification/") {
+		t.Fatalf("AZURE_REST_REPO_DIR must specify the specification folder, e.g., AZURE_REST_REPO_DIR=\"/home/test/go/src/github.com/azure/azure-rest-api-specs/specification/\"")
 	}
 
 	t.Logf("azure repo dir: %s", azureRepoDir)
@@ -72,9 +147,11 @@ func TestExpandAll(t *testing.T) {
 	}
 	index = nil
 
+	// expand concurrently
 	refChan := make(chan *jsonreference.Ref)
 
-	totalPropCount := 0
+	counter := sync.Map{}
+
 	var waitGroup sync.WaitGroup
 	waitGroup.Add(runtime.NumCPU())
 	for i := 0; i < runtime.NumCPU(); i++ {
@@ -87,10 +164,23 @@ func TestExpandAll(t *testing.T) {
 					panic(fmt.Errorf("get model info from index ref %s: %+v", ref.String(), err))
 				}
 
-				_, err = coverage.Expand(model.ModelName, model.SwaggerPath)
+				if model.ModelName == "" {
+					t.Logf("model not found, skip %s", ref.String())
+					continue
+				}
+
+				expanded, err := coverage.Expand(model.ModelName, model.SwaggerPath)
 				if err != nil {
+					if strings.Contains(err.Error(), "not found in the definition of") {
+						// https://github.com/Azure/azure-rest-api-specs/blob/f5cb37608399dd19760b9ef985a707294e32fbda/specification/vmware/resource-manager/Microsoft.AVS/stable/2021-06-01/vmware.json#L247
+						t.Logf("model %s not found in the definition, skip %s", model.ModelName, ref.String())
+						continue
+					}
 					panic(fmt.Errorf("process %s, expand %s from %s: %+v", ref.String(), model.ModelName, model.SwaggerPath, err))
 				}
+
+				expanded.CountCoverage()
+				counter.Store(ref.String(), expanded.TotalCount)
 
 				// clean up
 				model = nil
@@ -101,9 +191,53 @@ func TestExpandAll(t *testing.T) {
 		}(i)
 	}
 
+	refList := make([]*jsonreference.Ref, 0)
 	for _, ref := range refMaps {
+		refList = append(refList, ref)
+	}
+	sort.Slice(refList, func(i, j int) bool {
+		return refList[i].String() < refList[j].String()
+	})
+	for _, ref := range refList {
 		refChan <- ref
 	}
+	close(refChan)
 
-	t.Logf("refs numbers: %d, total prop count: %d", len(refMaps), totalPropCount)
+	waitGroup.Wait()
+
+	type res struct {
+		AllRef   int            `json:"all_ref"`
+		AllProp  int            `json:"all_prop"`
+		AvailRef int            `json:"avail_ref"`
+		Paths    map[string]int `json:"paths"`
+	}
+
+	result := res{
+		AllRef:   len(refMaps),
+		AllProp:  0,
+		AvailRef: 0,
+		Paths:    make(map[string]int),
+	}
+	counter.Range(func(key, value interface{}) bool {
+		result.Paths[key.(string)] = value.(int)
+		result.AvailRef += 1
+		result.AllProp += value.(int)
+		return true
+	})
+
+	t.Logf("total refs count: %d, ref with model: %d, total prop count: %d", result.AllRef, result.AvailRef, result.AllProp)
+
+	b, err := json.MarshalIndent(result, "", "\t")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	testResultFile := os.Getenv("TEST_RESULT_FILE")
+	if testResultFile == "" {
+		t.Log(string(b))
+	} else {
+		if err := os.WriteFile(testResultFile, b, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
 }

--- a/coverage/expand_test.go
+++ b/coverage/expand_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ms-henglu/armstrong/coverage"
 )
 
-func TestExpand(t *testing.T) {
+func TestExpand_MediaTranform(t *testing.T) {
 	modelName := "Transform"
 	modelSwaggerPath := "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/mediaservices/resource-manager/Microsoft.Media/Encoding/stable/2022-07-01/Encoding.json"
 	model, err := coverage.Expand(modelName, modelSwaggerPath)
@@ -101,17 +101,10 @@ func TestExpandAll(t *testing.T) {
 					}
 					if param.In == "body" {
 						if paramRef.String() != "" {
-							_, paramRelativePath := coverage.SchemaNamePathFromRef(paramRef)
-							if paramRelativePath != "" {
-								swaggerPath = filepath.Join(filepath.Dir(swaggerPath), paramRelativePath)
-							}
+							_, swaggerPath = coverage.SchemaNamePathFromRef(swaggerPath, paramRef)
 						}
 
-						var modelRelativePath string
-						modelName, modelRelativePath = coverage.SchemaNamePathFromRef(param.Schema.Ref)
-						if modelRelativePath != "" {
-							swaggerPath = filepath.Join(filepath.Dir(swaggerPath), modelRelativePath)
-						}
+						modelName, swaggerPath = coverage.SchemaNamePathFromRef(swaggerPath, param.Schema.Ref)
 						break
 					}
 				}

--- a/coverage/expand_test.go
+++ b/coverage/expand_test.go
@@ -72,10 +72,9 @@ func TestExpandAll(t *testing.T) {
 	}
 	index = nil
 
-	t.Logf("refs numbers: %d", len(refMaps))
-
 	refChan := make(chan *jsonreference.Ref)
 
+	totalPropCount := 0
 	var waitGroup sync.WaitGroup
 	waitGroup.Add(runtime.NumCPU())
 	for i := 0; i < runtime.NumCPU(); i++ {
@@ -105,4 +104,6 @@ func TestExpandAll(t *testing.T) {
 	for _, ref := range refMaps {
 		refChan <- ref
 	}
+
+	t.Logf("refs numbers: %d, total prop count: %d", len(refMaps), totalPropCount)
 }

--- a/coverage/expand_test.go
+++ b/coverage/expand_test.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/jsonreference"
 	openapispec "github.com/go-openapi/spec"
@@ -31,7 +33,7 @@ func TestExpand_MediaTransform(t *testing.T) {
 	t.Logf("expanded model %s", string(out))
 }
 
-func TestExpandLocal_basic(t *testing.T) {
+func TestExpand_referToChildVariant(t *testing.T) {
 	swaggerPath := "./testdata/"
 	pathRef := jsonreference.MustCreateRef("test1.json#/paths/~1path1/put")
 	swaggerModel, err := coverage.GetModelInfoFromIndexRef(openapispec.Ref{Ref: pathRef}, swaggerPath)
@@ -74,35 +76,35 @@ func TestExpandLocal_basic(t *testing.T) {
 		t.Fatalf("expected variantType animal.pet")
 	}
 
-	if _, ok := (*model.Variants)["animal.pet.dog"]; !ok {
+	if _, ok := (*model.Variants)["dog"]; !ok {
 		t.Fatalf("expected variants dog not nil")
 	}
 
-	if (*model.Variants)["animal.pet.dog"].Properties == nil {
+	if (*model.Variants)["dog"].Properties == nil {
 		t.Fatalf("expected variants dog properties not nil")
 	}
 
-	if (*model.Variants)["animal.pet.dog"].VariantType == nil || *(*model.Variants)["animal.pet.dog"].VariantType != "animal.pet.dog" {
+	if (*model.Variants)["dog"].VariantType == nil || *(*model.Variants)["dog"].VariantType != "animal.pet.dog" {
 		t.Fatalf("expected variants dog variantType animal.pet.dog")
 	}
 
-	if _, ok := (*(*model.Variants)["animal.pet.dog"].Properties)["odata.type"]; !ok {
+	if _, ok := (*(*model.Variants)["dog"].Properties)["odata.type"]; !ok {
 		t.Fatalf("expected variants dog properties odata.type string")
 	}
 
-	if _, ok := (*(*model.Variants)["animal.pet.dog"].Properties)["name"]; !ok {
+	if _, ok := (*(*model.Variants)["dog"].Properties)["name"]; !ok {
 		t.Fatalf("expected variants dog properties name")
 	}
 
-	if _, ok := (*(*model.Variants)["animal.pet.dog"].Properties)["is_barking"]; !ok {
+	if _, ok := (*(*model.Variants)["dog"].Properties)["is_barking"]; !ok {
 		t.Fatalf("expected variants dog properties name")
 	}
 
 }
 
-// try to expand all PUT and POST models
+// try to expand all PUT and POST models twice, and ensure result is the same
+// AZURE_REST_REPO_DIR="/home/test/go/src/github.com/azure/azure-rest-api-specs/specification" TEST_RESULT_FILE="/home/test/"
 func TestExpandAll(t *testing.T) {
-	// AZURE_REST_REPO_DIR="/home/test/go/src/github.com/azure/azure-rest-api-specs/specification" TEST_RESULT_FILE="/home/test/res.json"
 	azureRepoDir := os.Getenv("AZURE_REST_REPO_DIR")
 	if azureRepoDir == "" {
 		t.Skip("AZURE_REST_REPO_DIR is not set")
@@ -115,12 +117,95 @@ func TestExpandAll(t *testing.T) {
 	}
 
 	t.Logf("azure repo dir: %s", azureRepoDir)
+
+	testResultFilePath := os.Getenv("TEST_RESULT_PATH")
+
+	res := testExpandAll(t, azureRepoDir, resultFile(testResultFilePath))
+	res2 := testExpandAll(t, azureRepoDir, resultFile(testResultFilePath))
+	if res.AllRef != res2.AllRef || res.AllProp != res2.AllProp || res.AvailRef != res2.AvailRef {
+		t.Fatalf("result not equal, res1: %+v, res2: %+v", res, res2)
+	}
+}
+
+func resultFile(testResultFilePath string) string {
+	return filepath.Join(testResultFilePath, fmt.Sprintf("res_%s.json", time.Now().Format(time.RFC3339)))
+}
+
+type result struct {
+	AllRef   int            `json:"all_ref"`
+	AllProp  int            `json:"all_prop"`
+	AvailRef int            `json:"avail_ref"`
+	Paths    map[string]int `json:"paths"`
+}
+
+func testExpandAll(t *testing.T, azureRepoDir, testResultPath string) result {
+	refList := getRefList(t)
+	for _, ref := range refList {
+		t.Logf("ref: %s", ref.String())
+	}
+
+	// expand concurrently
+	res := result{
+		AllRef:   len(refList),
+		AllProp:  0,
+		AvailRef: 0,
+		Paths:    make(map[string]int),
+	}
+	refChan := make(chan jsonreference.Ref)
+	lock := sync.RWMutex{}
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(runtime.NumCPU())
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func(i int) {
+			for ref := range refChan {
+				t.Logf("%v ref: %v", i, ref.String())
+				count := expandRef(ref, azureRepoDir, t)
+
+				lock.Lock()
+				if count != 0 {
+					res.Paths[ref.String()] = count
+					res.AllProp += count
+					res.AvailRef += 1
+				}
+				lock.Unlock()
+			}
+			waitGroup.Done()
+		}(i)
+	}
+
+	for _, ref := range refList {
+		refChan <- ref
+	}
+	close(refChan)
+
+	waitGroup.Wait()
+
+	t.Logf("total refs count: %d, ref with model: %d, total prop count: %d", res.AllRef, res.AvailRef, res.AllProp)
+
+	b, err := json.MarshalIndent(res, "", "\t")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if testResultPath == "" {
+		t.Log(string(b))
+	} else {
+		if err := os.WriteFile(testResultPath, b, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return res
+}
+
+func getRefList(t *testing.T) []jsonreference.Ref {
 	index, err := coverage.GetIndex()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	refMaps := make(map[string]*jsonreference.Ref, 0)
+	refMaps := make(map[string]jsonreference.Ref, 0)
 	for resourceProvider, versionRaw := range index.ResourceProviders {
 		for version, methodRaw := range versionRaw {
 			for operationKind, resourceTypeRaw := range methodRaw {
@@ -133,111 +218,55 @@ func TestExpandAll(t *testing.T) {
 					}
 					for action, operationRefs := range operationInfo.Actions {
 						for pathPattern, ref := range operationRefs {
-							t.Logf("%s %s %s %s %s %s", resourceProvider, version, operationKind, resourceType, action, pathPattern)
-							refMaps[ref.String()] = &ref
+							t.Logf("%s %s %s %s %s %s: %s", resourceProvider, version, operationKind, resourceType, action, pathPattern, ref.String())
+							refMaps[ref.String()] = ref
 						}
 					}
 					for pathPattern, ref := range operationInfo.OperationRefs {
-						t.Logf("%s %s %s %s %s", resourceProvider, version, operationKind, resourceType, pathPattern)
-						refMaps[ref.String()] = &ref
+						t.Logf("%s %s %s %s %s: %s", resourceProvider, version, operationKind, resourceType, pathPattern, ref.String())
+						refMaps[ref.String()] = ref
 					}
 				}
 			}
 		}
 	}
-	index = nil
 
-	// expand concurrently
-	refChan := make(chan *jsonreference.Ref)
-
-	counter := sync.Map{}
-
-	var waitGroup sync.WaitGroup
-	waitGroup.Add(runtime.NumCPU())
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func(i int) {
-			for ref := range refChan {
-				t.Logf("%v ref: %v", i, ref.String())
-
-				model, err := coverage.GetModelInfoFromIndexRef(openapispec.Ref{Ref: *ref}, azureRepoDir)
-				if err != nil {
-					panic(fmt.Errorf("get model info from index ref %s: %+v", ref.String(), err))
-				}
-
-				if model.ModelName == "" {
-					t.Logf("model not found, skip %s", ref.String())
-					continue
-				}
-
-				expanded, err := coverage.Expand(model.ModelName, model.SwaggerPath)
-				if err != nil {
-					if strings.Contains(err.Error(), "not found in the definition of") {
-						// https://github.com/Azure/azure-rest-api-specs/blob/f5cb37608399dd19760b9ef985a707294e32fbda/specification/vmware/resource-manager/Microsoft.AVS/stable/2021-06-01/vmware.json#L247
-						t.Logf("model %s not found in the definition, skip %s", model.ModelName, ref.String())
-						continue
-					}
-					panic(fmt.Errorf("process %s, expand %s from %s: %+v", ref.String(), model.ModelName, model.SwaggerPath, err))
-				}
-
-				expanded.CountCoverage()
-				counter.Store(ref.String(), expanded.TotalCount)
-
-				// clean up
-				model = nil
-				ref = nil
-			}
-
-			waitGroup.Done()
-		}(i)
-	}
-
-	refList := make([]*jsonreference.Ref, 0)
+	refList := make([]jsonreference.Ref, 0)
 	for _, ref := range refMaps {
 		refList = append(refList, ref)
 	}
 	sort.Slice(refList, func(i, j int) bool {
 		return refList[i].String() < refList[j].String()
 	})
-	for _, ref := range refList {
-		refChan <- ref
-	}
-	close(refChan)
 
-	waitGroup.Wait()
-
-	type res struct {
-		AllRef   int            `json:"all_ref"`
-		AllProp  int            `json:"all_prop"`
-		AvailRef int            `json:"avail_ref"`
-		Paths    map[string]int `json:"paths"`
+	for i, ref := range refList {
+		t.Logf("refList ref %d: %s", i, ref.String())
 	}
 
-	result := res{
-		AllRef:   len(refMaps),
-		AllProp:  0,
-		AvailRef: 0,
-		Paths:    make(map[string]int),
-	}
-	counter.Range(func(key, value interface{}) bool {
-		result.Paths[key.(string)] = value.(int)
-		result.AvailRef += 1
-		result.AllProp += value.(int)
-		return true
-	})
+	return refList
+}
 
-	t.Logf("total refs count: %d, ref with model: %d, total prop count: %d", result.AllRef, result.AvailRef, result.AllProp)
-
-	b, err := json.MarshalIndent(result, "", "\t")
+func expandRef(ref jsonreference.Ref, azureRepoDir string, t *testing.T) int {
+	model, err := coverage.GetModelInfoFromIndexRef(openapispec.Ref{Ref: ref}, azureRepoDir)
 	if err != nil {
-		log.Fatal(err)
+		panic(fmt.Errorf("get model info from index ref %s: %+v", ref.String(), err))
 	}
 
-	testResultFile := os.Getenv("TEST_RESULT_FILE")
-	if testResultFile == "" {
-		t.Log(string(b))
-	} else {
-		if err := os.WriteFile(testResultFile, b, 0644); err != nil {
-			t.Fatal(err)
-		}
+	if model.ModelName == "" {
+		t.Logf("model not found, skip %s", ref.String())
+		return 0
 	}
+
+	expanded, err := coverage.Expand(model.ModelName, model.SwaggerPath)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found in the definition of") {
+			// https://github.com/Azure/azure-rest-api-specs/blob/f5cb37608399dd19760b9ef985a707294e32fbda/specification/vmware/resource-manager/Microsoft.AVS/stable/2021-06-01/vmware.json#L247
+			t.Logf("model %s not found in the definition, skip %s", model.ModelName, ref.String())
+			return 0
+		}
+		panic(fmt.Errorf("process %s, expand %s from %s: %+v", ref.String(), model.ModelName, model.SwaggerPath, err))
+	}
+
+	expanded.CountCoverage()
+	return expanded.TotalCount
 }

--- a/coverage/expand_test.go
+++ b/coverage/expand_test.go
@@ -35,8 +35,8 @@ func TestExpandAll(t *testing.T) {
 	if azureRepoDir == "" {
 		t.Skip("AZURE_REST_REPO_DIR is not set")
 	}
-	if !strings.HasSuffix(azureRepoDir, "specification/") {
-		t.Fatalf("AZURE_REST_REPO_DIR must specify the specification folder, e.g., AZURE_REST_REPO_DIR=\"/home/test/go/src/github.com/azure/azure-rest-api-specs/specification/\"")
+	if !strings.HasSuffix(azureRepoDir, "/specification") {
+		t.Fatalf("AZURE_REST_REPO_DIR must specify the specification folder, e.g., AZURE_REST_REPO_DIR=\"/home/test/go/src/github.com/azure/azure-rest-api-specs/specification\"")
 	}
 
 	t.Logf("azure repo dir: %s", azureRepoDir)

--- a/coverage/index_test.go
+++ b/coverage/index_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ms-henglu/armstrong/coverage"
 )
 
-func TestGetModelInfoFromIndex(t *testing.T) {
+func TestGetModelInfoFromIndex_DataCollectionRule(t *testing.T) {
 	apiVersion := "2022-06-01"
 	swaggerModel, err := coverage.GetModelInfoFromIndex(
 		"/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-resources/providers/Microsoft.Insights/dataCollectionRules/testDCR",
@@ -27,6 +27,32 @@ func TestGetModelInfoFromIndex(t *testing.T) {
 	}
 
 	expectedModelSwaggerPath := "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/monitor/resource-manager/Microsoft.Insights/stable/2022-06-01/dataCollectionRules_API.json"
+	if swaggerModel.SwaggerPath != expectedModelSwaggerPath {
+		t.Fatalf("expected modelSwaggerPath %s, got %s", expectedModelSwaggerPath, swaggerModel.SwaggerPath)
+	}
+}
+
+func TestGetModelInfoFromIndex_DeviceSecurityGroups(t *testing.T) {
+	apiVersion := "2019-08-01"
+	swaggerModel, err := coverage.GetModelInfoFromIndex(
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SampleRG/providers/Microsoft.Devices/iotHubs/sampleiothub/providers/Microsoft.Security/deviceSecurityGroups/samplesecuritygroup",
+		apiVersion,
+	)
+	if err != nil {
+		t.Fatalf("get model info from index error: %+v", err)
+	}
+
+	expectedApiPath := "/{resourceId}/providers/Microsoft.Security/deviceSecurityGroups/{deviceSecurityGroupName}"
+	if swaggerModel.ApiPath != expectedApiPath {
+		t.Fatalf("expected apiPath %s, got %s", expectedApiPath, swaggerModel.ApiPath)
+	}
+
+	expectedModelName := "DeviceSecurityGroup"
+	if swaggerModel.ModelName != expectedModelName {
+		t.Fatalf("expected modelName %s, got %s", expectedModelName, swaggerModel.ModelName)
+	}
+
+	expectedModelSwaggerPath := "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/security/resource-manager/Microsoft.Security/stable/2019-08-01/deviceSecurityGroups.json"
 	if swaggerModel.SwaggerPath != expectedModelSwaggerPath {
 		t.Fatalf("expected modelSwaggerPath %s, got %s", expectedModelSwaggerPath, swaggerModel.SwaggerPath)
 	}

--- a/coverage/report.go
+++ b/coverage/report.go
@@ -26,11 +26,11 @@ func (c *CoverageReport) AddCoverageFromState(resourceId, resourceType string, j
 
 	swaggerModel, err := GetModelInfoFromIndex(resourceId, apiVersion)
 	if err != nil {
-		return fmt.Errorf("error find the path for %s from index:%s", resourceId, err)
+		return fmt.Errorf("error find the path for %s from index: %+v", resourceId, err)
 
 	}
 
-	log.Printf("[INFO] matched API path:%s modelSwawggerPath:%s\n", swaggerModel.ApiPath, swaggerModel.SwaggerPath)
+	log.Printf("[INFO] matched API path: %s; modelSwawggerPath: %s\n", swaggerModel.ApiPath, swaggerModel.SwaggerPath)
 
 	resource := ArmResource{
 		ApiPath: swaggerModel.ApiPath,
@@ -40,7 +40,7 @@ func (c *CoverageReport) AddCoverageFromState(resourceId, resourceType string, j
 	if _, ok := c.Coverages[resource]; !ok {
 		expanded, err := Expand(swaggerModel.ModelName, swaggerModel.SwaggerPath)
 		if err != nil {
-			return fmt.Errorf("error expand model %s property:%s", swaggerModel.ModelName, err)
+			return fmt.Errorf("error expand model %s property: %+v", swaggerModel.ModelName, err)
 		}
 
 		c.Coverages[resource] = expanded

--- a/coverage/report.go
+++ b/coverage/report.go
@@ -3,7 +3,6 @@ package coverage
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 )
 
@@ -17,12 +16,7 @@ type CoverageReport struct {
 }
 
 func (c *CoverageReport) AddCoverageFromState(resourceId, resourceType string, jsonBody map[string]interface{}) error {
-	var err error
-
 	apiVersion := strings.Split(resourceType, "@")[1]
-	if !regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}$`).MatchString(apiVersion) {
-		return fmt.Errorf("could not parse apiVersion from resourceType: %s", resourceType)
-	}
 
 	swaggerModel, err := GetModelInfoFromIndex(resourceId, apiVersion)
 	if err != nil {

--- a/coverage/testdata/test1.json
+++ b/coverage/testdata/test1.json
@@ -55,7 +55,7 @@
           "type": "string"
         }
       },
-        "x-ms-discriminator-value": "animal.pet"
+      "x-ms-discriminator-value": "animal.pet"
     },
     "dog": {
       "type": "object",

--- a/coverage/testdata/test1.json
+++ b/coverage/testdata/test1.json
@@ -1,0 +1,75 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "",
+    "title": ""
+  },
+  "paths": {
+    "/path1": {
+      "put": {
+        "parameters": [
+          {
+            "$ref": "#/parameters/location"
+          },
+          {
+            "$ref": "./test2.json#/parameters/version"
+          },
+          {
+            "$ref": "./test2.json#/parameters/input1"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "location": {
+      "in": "query",
+      "name": "location",
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "animal": {
+      "type": "object",
+      "discriminator": "odata.type",
+      "properties": {
+        "odata.type": {
+          "type": "string"
+        }
+      }
+    },
+    "pet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/animal"
+        }
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+        "x-ms-discriminator-value": "animal.pet"
+    },
+    "dog": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/pet"
+        }
+      ],
+      "properties": {
+        "is_barking": {
+          "type": "boolean"
+        }
+      },
+      "x-ms-discriminator-value": "animal.pet.dog"
+    }
+  }
+}

--- a/coverage/testdata/test2.json
+++ b/coverage/testdata/test2.json
@@ -1,8 +1,6 @@
 {
   "swagger": "2.0",
-  "paths": {
-
-  },
+  "paths": {},
   "info": {
     "version": "",
     "title": ""

--- a/coverage/testdata/test2.json
+++ b/coverage/testdata/test2.json
@@ -1,0 +1,25 @@
+{
+  "swagger": "2.0",
+  "paths": {
+
+  },
+  "info": {
+    "version": "",
+    "title": ""
+  },
+  "parameters": {
+    "input1": {
+      "name": "input",
+      "in": "body",
+      "required": true,
+      "schema": {
+        "$ref": "./test1.json#/definitions/pet"
+      }
+    },
+    "version": {
+      "in": "query",
+      "name": "version",
+      "type": "string"
+    }
+  }
+}

--- a/report/pass_report.go
+++ b/report/pass_report.go
@@ -60,10 +60,10 @@ func PassedMarkdownReport(passReport types.PassReport, coverageReport coverage.C
 [swagger](%[3]v)
 <blockquote>
 <details open>
-<summary><span%[4]v>body(%[5]v/%[6]v)</span></summary>
+<summary><span%[4]v>%[5]v(%[6]v/%[7]v)</span></summary>
 <blockquote>
 
-%[7]v
+%[8]v
 
 </blockquote>
 </details>
@@ -72,7 +72,7 @@ func PassedMarkdownReport(passReport types.PassReport, coverageReport coverage.C
 </details>
 
 ---
-`, k.Type, k.ApiPath, v.SourceFile, getStyle(v.IsFullyCovered), v.CoveredCount, v.TotalCount, strings.Join(reportDetail, "\n\n")))
+`, k.Type, k.ApiPath, v.SourceFile, getStyle(v.IsFullyCovered), v.ModelName, v.CoveredCount, v.TotalCount, strings.Join(reportDetail, "\n\n")))
 	}
 
 	sort.Strings(coverages)

--- a/report/pass_report.go
+++ b/report/pass_report.go
@@ -110,15 +110,31 @@ func getReport(model *coverage.Model) []string {
 			}
 
 			if v.Variants != nil {
-				for variantType, variant := range *v.Variants {
-					out = append(out, getChildReport(fmt.Sprintf("%s{%s}", k, variantType), variant))
+				for variantName, variant := range *v.Variants {
+					variantKey := fmt.Sprintf("%s{%s}", k, variantName)
+					if variant == nil {
+						// reference to self
+						out = append(out, getChildReport(variantKey, v))
+						continue
+					}
+
+					out = append(out, getChildReport(variantKey, variant))
 				}
+				continue
 			}
 
 			if v.Item != nil && v.Item.Variants != nil {
 				for variantType, variant := range *v.Item.Variants {
-					out = append(out, getChildReport(fmt.Sprintf("%s{%s}", k, variantType), variant))
+					variantKey := fmt.Sprintf("%s{%s}", k, variantType)
+					if variant == nil {
+						// reference to self
+						out = append(out, getChildReport(variantKey, v))
+						continue
+					}
+
+					out = append(out, getChildReport(variantKey, variant))
 				}
+				continue
 			}
 
 			out = append(out, getChildReport(k, v))

--- a/report/pass_report.go
+++ b/report/pass_report.go
@@ -117,8 +117,13 @@ func getReport(model *coverage.Model) []string {
 			}
 
 			if v.Variants != nil {
-				for variantName, variant := range *v.Variants {
-					variantKey := fmt.Sprintf("%s{%s}", k, variantName)
+				for variantType, variant := range *v.Variants {
+					variantType := variantType
+					if v.VariantType != nil {
+						variantType = *v.Item.VariantType
+					}
+					variantKey := fmt.Sprintf("%s{%s}", k, variantType)
+
 					if variant == nil {
 						// reference to self
 						out = append(out, getChildReport(variantKey, v))
@@ -132,7 +137,12 @@ func getReport(model *coverage.Model) []string {
 
 			if v.Item != nil && v.Item.Variants != nil {
 				for variantType, variant := range *v.Item.Variants {
+					variantType := variantType
+					if v.Item.VariantType != nil {
+						variantType = *v.Item.VariantType
+					}
 					variantKey := fmt.Sprintf("%s{%s}", k, variantType)
+
 					if variant == nil {
 						// reference to self
 						out = append(out, getChildReport(variantKey, v))

--- a/report/pass_report.go
+++ b/report/pass_report.go
@@ -25,6 +25,12 @@ func PassedMarkdownReport(passReport types.PassReport, coverageReport coverage.C
 	content := passedReportTemplate
 	content = strings.ReplaceAll(content, "${resource_type}", strings.Join(resourceTypes, "\n"))
 
+	content = addCoverageReport(content, coverageReport)
+
+	return content
+}
+
+func addCoverageReport(content string, coverageReport coverage.CoverageReport) string {
 	fullyCoveredPath := make([]string, 0)
 	partiallyCoveredPath := make([]string, 0)
 	for k, v := range coverageReport.Coverages {
@@ -77,6 +83,7 @@ func PassedMarkdownReport(passReport types.PassReport, coverageReport coverage.C
 
 	sort.Strings(coverages)
 	content = strings.ReplaceAll(content, "${coverage_details}", strings.Join(coverages, "\n"))
+
 	return content
 }
 

--- a/report/pass_report.go
+++ b/report/pass_report.go
@@ -117,38 +117,39 @@ func getReport(model *coverage.Model) []string {
 			}
 
 			if v.Variants != nil {
+				variantType := v.ModelName
+				if v.VariantType != nil {
+					variantType = *v.VariantType
+				}
+				variantKey := fmt.Sprintf("%s{%s}", k, variantType)
+
+				out = append(out, getChildReport(variantKey, v))
+
 				for variantType, variant := range *v.Variants {
 					variantType := variantType
-					if v.VariantType != nil {
-						variantType = *v.Item.VariantType
+					if variant.VariantType != nil {
+						variantType = *variant.VariantType
 					}
 					variantKey := fmt.Sprintf("%s{%s}", k, variantType)
-
-					if variant == nil {
-						// reference to self
-						out = append(out, getChildReport(variantKey, v))
-						continue
-					}
-
 					out = append(out, getChildReport(variantKey, variant))
 				}
 				continue
 			}
 
 			if v.Item != nil && v.Item.Variants != nil {
+				variantType := v.Item.ModelName
+				if v.Item.VariantType != nil {
+					variantType = *v.Item.VariantType
+				}
+				variantKey := fmt.Sprintf("%s{%s}", k, variantType)
+				out = append(out, getChildReport(variantKey, v))
+
 				for variantType, variant := range *v.Item.Variants {
 					variantType := variantType
-					if v.Item.VariantType != nil {
-						variantType = *v.Item.VariantType
+					if variant.VariantType != nil {
+						variantType = *variant.VariantType
 					}
 					variantKey := fmt.Sprintf("%s{%s}", k, variantType)
-
-					if variant == nil {
-						// reference to self
-						out = append(out, getChildReport(variantKey, v))
-						continue
-					}
-
 					out = append(out, getChildReport(variantKey, variant))
 				}
 				continue

--- a/resource/data_source_test.go
+++ b/resource/data_source_test.go
@@ -15,8 +15,7 @@ func TestDataSource_NewDataSourceFromExample(t *testing.T) {
 	}
 	if r == nil {
 		t.Fatal("expect valid resource, but got nil")
-	}
-	if r.ApiVersion != "2020-06-01" {
+	} else if r.ApiVersion != "2020-06-01" {
 		t.Fatalf("expect api-version 2020-06-01, but got %s", r.ApiVersion)
 	}
 

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -15,8 +15,7 @@ func TestResource_NewResourceFromExample(t *testing.T) {
 	}
 	if r == nil {
 		t.Fatal("expect valid resource, but got nil")
-	}
-	if r.ApiVersion != "2020-06-01" {
+	} else if r.ApiVersion != "2020-06-01" {
 		t.Fatalf("expect api-version 2020-06-01, but got %s", r.ApiVersion)
 	}
 

--- a/tf/utils.go
+++ b/tf/utils.go
@@ -147,6 +147,12 @@ func NewPassReport(plan *tfjson.Plan) types.PassReport {
 }
 
 func NewCoverageReportFromState(state *tfjson.State) (coverage.CoverageReport, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[ERROR] panic when producing coverage report from state: %+v", r)
+		}
+	}()
+
 	out := coverage.CoverageReport{
 		Coverages: make(map[coverage.ArmResource]*coverage.Model, 0),
 	}
@@ -182,6 +188,12 @@ func NewCoverageReportFromState(state *tfjson.State) (coverage.CoverageReport, e
 }
 
 func NewCoverageReport(plan *tfjson.Plan) (coverage.CoverageReport, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[ERROR] panic when producing coverage report: %+v", r)
+		}
+	}()
+
 	out := coverage.CoverageReport{
 		Coverages: make(map[coverage.ArmResource]*coverage.Model, 0),
 	}


### PR DESCRIPTION
- prevent the program from crashing if there is an error generating the coverage report.
- add a test that uses local swagger test data to verify that the code is working correctly.
- add a test that expands all PUT and POST models twice and compares the results to each other. This will help to ensure that the expand function is stable and that it is producing consistent results
- fix the discriminator resolve function to support cases where only the child variant is used, and cases where the `x-ms-discriminator-value extension` is not used
- This task will download the `index.zip` instead of `index.json` file and reduce its file size from 50MB to 2MB. 