### PR TITLE
generate: add check when reading api-version

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -49,7 +49,10 @@ func NewResourceFromExample(filepath string) (*Resource, error) {
 				}
 				mappings = append(mappings, GetKeyValueMappings(body, "")...)
 
-				apiVersion = parametersMap["api-version"].(string)
+				if apiVer, ok := parametersMap["api-version"].(string); ok {
+					apiVersion = apiVer
+				}
+
 			}
 		}
 


### PR DESCRIPTION
It used to panic if `api-version` was not specified in the example json file.
<img width="1128" alt="Screenshot 2023-10-13 at 10 32 22" src="https://github.com/ms-henglu/armstrong/assets/51212351/8c65dcec-688f-48a4-9d46-c5b40146d8e9">
